### PR TITLE
Add magic-move animations to slides with code snippets

### DIFF
--- a/drivers/base/regmap/regmap.md
+++ b/drivers/base/regmap/regmap.md
@@ -102,7 +102,6 @@ depending on the connection type.
 
 ---
 title: The *regmap_config* structure
-transition: fade
 ---
 
 # The `regmap_config` structure
@@ -110,6 +109,8 @@ transition: fade
 - Defined in `include/linux/regmap.h`.
 - Provides configuration options for `struct regmap`.
 - Let's see some interesting elements (most are optional):
+
+````md magic-move
 
 ```c
 struct regmap_config {
@@ -122,17 +123,6 @@ struct regmap_config {
 }
 ```
 
----
-title: ' '
-transition: fade
----
-
-# The `regmap_config` structure
-
-- Defined in `include/linux/regmap.h`.
-- Provides configuration options for `struct regmap`.
-- Let's see some interesting elements (most are optional):
-
 ```c
 struct regmap_config {
     [...]
@@ -143,17 +133,6 @@ struct regmap_config {
     [...]
 }
 ```
-
----
-title: ' '
-transition: fade
----
-
-# The `regmap_config` structure
-
-- Defined in `include/linux/regmap.h`.
-- Provides configuration options for `struct regmap`.
-- Let's see some interesting elements (most are optional):
 
 ```c
 struct regmap_config {
@@ -167,17 +146,6 @@ struct regmap_config {
 }
 ```
 
----
-title: ' '
-transition: fade
----
-
-# The `regmap_config` structure
-
-- Defined in `include/linux/regmap.h`.
-- Provides configuration options for `struct regmap`.
-- Let's see some interesting elements (most are optional):
-
 ```c
 struct regmap_config {
     [...]
@@ -186,17 +154,6 @@ struct regmap_config {
     [...]
 }
 ```
-
----
-title: ' '
-transition: fade
----
-
-# The `regmap_config` structure
-
-- Defined in `include/linux/regmap.h`.
-- Provides configuration options for `struct regmap`.
-- Let's see some interesting elements (most are optional):
 
 ```c
 struct regmap_config {
@@ -211,17 +168,6 @@ struct regmap_config {
 }
 ```
 
----
-title: ' '
-transition: fade
----
-
-# The `regmap_config` structure
-
-- Defined in `include/linux/regmap.h`.
-- Provides configuration options for `struct regmap`.
-- Let's see some interesting elements (most are optional):
-
 ```c
 struct regmap_config {
     [...]
@@ -232,16 +178,6 @@ struct regmap_config {
 }
 ```
 
----
-title: ' '
----
-
-# The `regmap_config` structure
-
-- Defined in `include/linux/regmap.h`.
-- Provides configuration options for `struct regmap`.
-- Let's see some interesting elements (most are optional):
-
 ```c
 struct regmap_config {
     [...]
@@ -251,6 +187,8 @@ struct regmap_config {
     [...]
 }
 ```
+
+````
 
 ---
 

--- a/drivers/base/regmap/regmap.md
+++ b/drivers/base/regmap/regmap.md
@@ -390,10 +390,11 @@ Basically the same as `regmap_read`: checks alignment, locks, calls internal
 ---
 level: 2
 title: The internal *_regmap_write*
-transition: fade
 ---
 
 # The internal `_regmap_write`
+
+````md magic-move
 
 ```c {all|6,7|9,10,17|9,11,12,17|9,13,14,15,16,17}
 int _regmap_write(struct regmap *map, unsigned int reg, unsigned int val)
@@ -417,14 +418,6 @@ int _regmap_write(struct regmap *map, unsigned int reg, unsigned int val)
 }
 ```
 
-If caching is not bypassed or deferred, writes in cache.
-
----
-title: ' '
----
-
-# The internal `_regmap_write`
-
 ```c {all|4|all}
 int _regmap_write(struct regmap *map, unsigned int reg, unsigned int val)
 {
@@ -441,6 +434,9 @@ int _regmap_write(struct regmap *map, unsigned int reg, unsigned int val)
 }
 ```
 
+````
+
+If caching is not bypassed or deferred, writes in cache.  
 Then, writes in the actual hardware register.
 
 ---

--- a/drivers/base/regmap/regmap.md
+++ b/drivers/base/regmap/regmap.md
@@ -309,10 +309,11 @@ to be a spinlock, for example with fast_io flag in regmap_config
 ---
 level: 2
 title: The internal *_regmap_read*
-transition: fade
 ---
 
 # The internal `_regmap_read`
+
+````md magic-move
 
 ```c {all|6,7,8,9,10|12,13|15,16}
 static int _regmap_read(struct regmap *map, unsigned int reg, unsigned int *val)
@@ -335,16 +336,6 @@ static int _regmap_read(struct regmap *map, unsigned int reg, unsigned int *val)
 }
 ```
 
-If supported, tries to read from cache.
-If not, or if cache miss, attempts to read register. If successful, then
-also writes result in cache.
-
----
-title: ' '
----
-
-# The internal `_regmap_read`
-
 ```c {all|4|5,11,12,13|all}
 static int _regmap_read(struct regmap *map, unsigned int reg, unsigned int *val)
 {
@@ -363,6 +354,7 @@ static int _regmap_read(struct regmap *map, unsigned int reg, unsigned int *val)
 }
 ```
 
+````
 
 If supported, tries to read from cache.
 If not, or if cache miss, attempts to read register. If successful, then


### PR DESCRIPTION
Add `md magic-move` animation to *The regmap_config structure*, *The internal _regmap_read* and *The internal _regmap_write*.
In this way we avoid fade-transitioning between many slides and we make the presentation more eye-catching.
