### PR TITLE
style: Add font-small and font-large

### DIFF
--- a/template/styles/layout.css
+++ b/template/styles/layout.css
@@ -34,6 +34,14 @@
   transform: translateY(-50%);
 }
 
+.font-small {
+  font-size: 14px;
+}
+
+.font-large {
+  font-size: 18px;
+}
+
 .content-image-right {
   vertical-align: center;
   margin-top: auto;


### PR DESCRIPTION
Example of usage:

<div class="center font-small">

</div>

Allow us to have slides with more text without overlap the title of the bottom of the slide