### PR TITLE
Cleanup and layout changes for regmap slides

### DIFF
--- a/drivers/base/regmap/regmap.md
+++ b/drivers/base/regmap/regmap.md
@@ -17,7 +17,6 @@ layout: cover
 
 ---
 layout: default
-title: ' '
 hideInToc: true
 ---
 
@@ -59,7 +58,6 @@ abstracting it for general use.
 ---
 layout: two-cols
 layoutClass: gap16
-title: ' '
 hideInToc: true
 
 ---
@@ -248,7 +246,6 @@ allocate space for and initialise a `struct regmap`.
 
 ---
 layout: fact
-title: ' '
 hideInToc: true
 ---
 
@@ -455,7 +452,6 @@ about devres! :)
 </div>
 ---
 layout: last-slide
-title: ' '
 hideInToc: true
 ---
 

--- a/drivers/base/regmap/regmap.md
+++ b/drivers/base/regmap/regmap.md
@@ -305,6 +305,7 @@ to be a spinlock, for example with fast_io flag in regmap_config
 ---
 level: 2
 title: The internal *_regmap_read*
+hideInToc: true
 ---
 
 # The internal `_regmap_read`
@@ -386,6 +387,7 @@ Basically the same as `regmap_read`: checks alignment, locks, calls internal
 ---
 level: 2
 title: The internal *_regmap_write*
+hideInToc: true
 ---
 
 # The internal `_regmap_write`


### PR DESCRIPTION
Remove useless `title: ' '` lines, as this function is already done by `hideInToc: true`.
Hide `internal` slides from TOC, to make it shorter and more simple.